### PR TITLE
Fix URL to Travis CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ django-session-timeout
 
 Status
 ======
-.. image:: https://travis-ci.org/LabD/django-session-timeout.svg?branch=master
-    :target: https://travis-ci.org/LabD/django-session-timeout
+.. image:: https://travis-ci.org/labd/django-session-timeout.svg?branch=master
+    :target: https://travis-ci.org/labd/django-session-timeout
 
 .. image:: http://codecov.io/github/LabD/django-session-timeout/coverage.svg?branch=master
     :target: http://codecov.io/github/LabD/django-session-timeout?branch=master


### PR DESCRIPTION
This makes the badge actually load and links to the builds page. Otherwise it says build|undefined and looks like this is a broken or unmaintained package.