### PR TITLE
Add ability to ignore certain URL paths when determining whether there is website activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ To redirect to a custom URL define the following setting:
 ```python
 SESSION_TIMEOUT_REDIRECT = 'your_redirect_url_here/'
 ```
+
+To ignore URL paths that are not considered "activity" (such as those used when browser code is regularly polling for status) put a regular expression matching the paths to be ignored in the following setting:
+
+```python
+SESSION_ACTIVITY_IGNORED_PATHS_REGEX = '/first/ignored/path|/another/ignored/path'
+```

--- a/src/django_session_timeout/middleware.py
+++ b/src/django_session_timeout/middleware.py
@@ -1,4 +1,5 @@
 import time
+import re
 
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
@@ -14,6 +15,18 @@ SESSION_TIMEOUT_KEY = "_session_init_timestamp_"
 
 
 class SessionTimeoutMiddleware(MiddlewareMixin):
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+        self.ignored_paths_regex = None
+
+        regex = getattr(settings, "SESSION_ACTIVITY_IGNORED_PATHS_REGEX", None)
+        if regex:
+            self.ignored_paths_regex = re.compile(regex)
+
+    def is_path_ignored(self, path):
+        ignored = self.ignored_paths_regex and bool(self.ignored_paths_regex.search(path))
+        return ignored
+
     def process_request(self, request):
         if not hasattr(request, "session") or request.session.is_empty():
             return
@@ -41,5 +54,7 @@ class SessionTimeoutMiddleware(MiddlewareMixin):
             settings, "SESSION_EXPIRE_AFTER_LAST_ACTIVITY_GRACE_PERIOD", 1
         )
 
-        if expire_since_last_activity and time.time() - init_time > grace_period:
+        if expire_since_last_activity \
+            and time.time() - init_time > grace_period \
+            and not self.is_path_ignored(request.path):
             request.session[SESSION_TIMEOUT_KEY] = time.time()


### PR DESCRIPTION
### Use Case

On some websites, regular "polling" accesses may be made by browser code to certain paths within the website. This will cause the session activity timer to incorrectly assume that there is still user activity when in fact the activity stems only from browser code. This change allows the session-timeout code to ignore user-specified paths.

The paths are configured as a single Regular Expression string in the `SESSION_ACTIVITY_IGNORED_PATHS_REGEX` variable in `settings.py`. Multiple paths are separated by the "|" (regex "or) character.

See the example in the Readme file.
